### PR TITLE
fix: resolve incompatible goreleaser versions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0
+
       - uses: orhun/git-cliff-action@4a4a951bc43fafe41cd2348d181853f52356bee7 # v4.4.2
         id: git-cliff
         with:
@@ -27,8 +28,10 @@ jobs:
           args: -vv --latest --prepend CHANGELOG.md --no-exec # https://git-cliff.org/docs/usage/args
         env:
           GITHUB_REPO: ${{ github.repository }}
+
       - name: Get Release Version
         run: echo "RELEASE_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
+
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           add-paths: CHANGELOG.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goreleaser/goreleaser/refs/tags/v2.3.2/www/docs/static/schema.json
 #
 # Visit https://goreleaser.com for documentation on how to customize this behavior.
 version: 2
@@ -25,9 +25,8 @@ builds:
     binary: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
 archives:
   - id: no-archive
-    ids:
+    builds:
       - main
-    formats:
-      - binary
+    format: binary
 changelog:
   disable: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,9 @@
 # Visit https://goreleaser.com for documentation on how to customize this behavior.
 version: 2
 
+before:
+  hooks:
+    - goreleaser check
 builds:
   - id: main
     main: ./cmd/plugin

--- a/devbox.json
+++ b/devbox.json
@@ -7,7 +7,12 @@
     "gotestfmt@2.5.0",
     "golangci-lint@2.1.6",
     "gopls@0.18.1",
-    "goreleaser@2.10.2",
+    /**
+     * We need to use the same version of goreleaser as the
+     * go-semantic-release hooks-goreleaser action uses.
+     * https://github.com/go-semantic-release/hooks-goreleaser/blob/main/go.mod
+     */
+    "goreleaser@2.3.2",
     "terraform@1.11.4",
     "open-policy-agent@1.4.2",
     /* tools */
@@ -16,6 +21,7 @@
     "markdownlint-cli2@0.18.1",
     "actionlint@1.7.7",
     "shellcheck@0.10.0",
+    "git-cliff@2.9.1",
     /* bats */
     "bats@1.11.0",
     "bats.libraries.bats-assert",

--- a/devbox.lock
+++ b/devbox.lock
@@ -139,6 +139,54 @@
         }
       }
     },
+    "git-cliff@2.9.1": {
+      "last_modified": "2025-06-20T02:24:11Z",
+      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#git-cliff",
+      "source": "devbox-search",
+      "version": "2.9.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/pd5nd925ri8h436b7m1g997kihfhfmi4-git-cliff-2.9.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/pd5nd925ri8h436b7m1g997kihfhfmi4-git-cliff-2.9.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wmlz3nczp17w7nhngfcz96ffj8dk2fgm-git-cliff-2.9.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/wmlz3nczp17w7nhngfcz96ffj8dk2fgm-git-cliff-2.9.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/r5bq1j3rjqvksmjnnzlk0ihq8q0crmyz-git-cliff-2.9.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/r5bq1j3rjqvksmjnnzlk0ihq8q0crmyz-git-cliff-2.9.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hsr6hkp9b6g3wbi8p35gh3jz3cdkyy9b-git-cliff-2.9.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hsr6hkp9b6g3wbi8p35gh3jz3cdkyy9b-git-cliff-2.9.1"
+        }
+      }
+    },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
       "last_modified": "2025-05-26T00:03:27Z",
       "resolved": "github:NixOS/nixpkgs/3108eaa516ae22c2360928589731a4f1581526ef?lastModified=1748217807&narHash=sha256-P3u2PXxMlo49PutQLnk2PhI%2FimC69hFl1yY4aT5Nax8%3D"
@@ -287,51 +335,51 @@
         }
       }
     },
-    "goreleaser@2.10.2": {
-      "last_modified": "2025-06-20T02:24:11Z",
-      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#goreleaser",
+    "goreleaser@2.3.2": {
+      "last_modified": "2024-11-03T14:18:04Z",
+      "resolved": "github:NixOS/nixpkgs/4ae2e647537bcdbb82265469442713d066675275#goreleaser",
       "source": "devbox-search",
-      "version": "2.10.2",
+      "version": "2.3.2",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/0rfcf2hr4kz33zw5pgrzhrdgvm6rxzkd-goreleaser-2.10.2",
+              "path": "/nix/store/gnhsc6zjrbqx714nn8lid7p3qbfzzpp4-goreleaser-2.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/0rfcf2hr4kz33zw5pgrzhrdgvm6rxzkd-goreleaser-2.10.2"
+          "store_path": "/nix/store/gnhsc6zjrbqx714nn8lid7p3qbfzzpp4-goreleaser-2.3.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/k2jqcphvdal0524497pqp5mybblvd8dn-goreleaser-2.10.2",
+              "path": "/nix/store/pq60y01nwxvamf690dksr65bs5sdqm7z-goreleaser-2.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/k2jqcphvdal0524497pqp5mybblvd8dn-goreleaser-2.10.2"
+          "store_path": "/nix/store/pq60y01nwxvamf690dksr65bs5sdqm7z-goreleaser-2.3.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/n5j2dlx2imbdyzxlaqx64f17kwk4zc8q-goreleaser-2.10.2",
+              "path": "/nix/store/h9hzbyr7avbb2i9qj5di43859md4yxjx-goreleaser-2.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/n5j2dlx2imbdyzxlaqx64f17kwk4zc8q-goreleaser-2.10.2"
+          "store_path": "/nix/store/h9hzbyr7avbb2i9qj5di43859md4yxjx-goreleaser-2.3.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/28bv45il6shhpz73mbzl1mll43vsrc71-goreleaser-2.10.2",
+              "path": "/nix/store/lw7kqjrwnv6k42jaiawzsg02nbm6yd44-goreleaser-2.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/28bv45il6shhpz73mbzl1mll43vsrc71-goreleaser-2.10.2"
+          "store_path": "/nix/store/lw7kqjrwnv6k42jaiawzsg02nbm6yd44-goreleaser-2.3.2"
         }
       }
     },

--- a/justfile
+++ b/justfile
@@ -51,6 +51,10 @@ help:
     @echo ""
     @just show-vars
 
+[private]
+create-bin-dir:
+    @mkdir -p {{ output_dir }}
+
 # Dependency Management
 
 # Download Go module dependencies
@@ -77,7 +81,7 @@ ensure-deps: download tidy
 
 # Build for a specific OS/arch (internal helper)
 [group('golang')]
-build target_os=go_os target_arch=go_arch: tidy
+build target_os=go_os target_arch=go_arch: create-bin-dir tidy
     GOARCH={{ target_arch }} \
     GOOS={{ target_os }} \
     goreleaser build \


### PR DESCRIPTION
## Purpose

Fixes our broken release pipeline, which was caused by breaking changes in the minor versions of `goreleaser` (`go-semantic-release/action` runs a version that is not the latest, so local had a different `goreleaser` to ci).

Reverts the `goreleaser` version in devbox to `2.3.2`
Adds a hook before we run goreleaser that runs `goreleaser check`
Also adds git-cliff to local for validating change logs locally

## Context

https://github.com/cultureamp/terraform-buildkite-plugin/actions/runs/15965486472/job/45025005694#step:4:34

## Breaking changes

N/A

## Related issues

N/A