### PR TITLE
fix: remove hook due to ci compatibility issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,6 @@ on:
   workflow_call:
   # when manually triggered
   workflow_dispatch:
-  # on pushes to main branch
-  push:
-    branches:
-      - main
-    paths:
-      - "**/**.go"
 
 jobs:
   release:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,9 +3,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this behavior.
 version: 2
 
-before:
-  hooks:
-    - goreleaser check
 builds:
   - id: main
     main: ./cmd/plugin


### PR DESCRIPTION
## Purpose

Remove the hook due to ci compatibility issues (the action doesn't expose the binary)
Remove the release trigger on main as it is already triggered by pipeline.yml

## Context

https://github.com/cultureamp/terraform-buildkite-plugin/actions/runs/15965842552/job/45026007300

## Breaking changes

N/A

## Related issues

N/A