### PR TITLE
ci: flip the incorrect branch vs base names

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -59,8 +59,8 @@ jobs:
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           add-paths: CHANGELOG.md
-          base: pre-release
-          branch: main
+          base: main
+          branch: pre-release
           commit-message: "chore(release): prepare changelog for ${{ steps.semrel.outputs.version }}"
           title: "chore: prepare release v${{ steps.semrel.outputs.version }}"
           body: |


### PR DESCRIPTION
## Purpose

flip the incorrect branch vs base names

## Context

https://github.com/cultureamp/terraform-buildkite-plugin/actions/runs/15998348102

## Breaking changes

N/A

## Related issues

N/A