### PR TITLE
ci: flip the incorrect branch vs base names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
       time: "22:00" # 10pm UTC
     labels:
+      - "bot"
       - "dependencies"
       - "go"
 
@@ -16,5 +17,6 @@ updates:
       interval: "weekly"
       time: "22:00" # 10pm UTC
     labels:
+      - "bot"
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -81,5 +81,5 @@ jobs:
 
             </details>
           labels: bot,release
-          # TODO: replace this token with a non PAT token)
+          # TODO: replace this token with a non PAT token
           token: ${{ secrets.PULL_REQUEST_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -61,14 +61,23 @@ jobs:
           add-paths: CHANGELOG.md
           base: main
           branch: pre-release
+          labels: bot,release
           commit-message: "chore(release): prepare changelog for ${{ steps.semrel.outputs.version }}"
           title: "chore: prepare release v${{ steps.semrel.outputs.version }}"
           body: |
-            :robot: This PR prepares the next release.
+            ## 🚀 Release Preview: v${{ steps.semrel.outputs.version }}
 
-            ## Proposed Version: `${{ steps.semrel.outputs.version }}`
+            This pull request was automatically generated to prepare the next release.
 
-            <details><summary>Changelog Details</summary>
+            It includes:
+            - An updated `CHANGELOG.md` with changes since the last release
+            - A proposed version bump to `v${{ steps.semrel.outputs.version }}` based on commit history
+
+            Once approved and merged into the `pre-release` branch, the release process will be triggered automatically.
+
+            <details>
+            <summary>📝 Full Changelog</summary>
 
             ${{ steps.git-cliff.outputs.content }}
+
             </details>

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -61,7 +61,6 @@ jobs:
           add-paths: CHANGELOG.md
           base: main
           branch: pre-release
-          labels: bot,release
           commit-message: "chore(release): prepare changelog for ${{ steps.semrel.outputs.version }}"
           title: "chore: prepare release v${{ steps.semrel.outputs.version }}"
           body: |
@@ -81,3 +80,6 @@ jobs:
             ${{ steps.git-cliff.outputs.content }}
 
             </details>
+          labels: bot,release
+          # TODO: replace this token with a non PAT token)
+          token: ${{ secrets.PULL_REQUEST_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose

- enhance pre-release PR body with detailed release preview and changelog
- add "bot" label to dependabot updates for gomod and github-actions
- add specialised token for the pull request action

## Context

https://github.com/peter-evans/create-pull-request#token

## Breaking changes

N/A

## Related issues

N/A