### PR TITLE
ci: add markdownlintignore for line length to `CHANGELOG.md`

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,31 +7,7 @@
   },
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "changelog-sections": [
-    {
-      "type": "feat",
-      "section": "Features"
-    },
-    {
-      "type": "fix",
-      "section": "Bug Fixes"
-    },
-    {
-      "type": "refactor",
-      "section": "Code Refactoring"
-    },
-    {
-      "type": "test",
-      "section": "Tests"
-    },
-    {
-      "type": "docs",
-      "section": "Documentation"
-    },
-    {
-      "type": "chore",
-      "section": "Miscellaneous Chores"
-    }
-  ],
-  "draft-pull-request": true
+  "draft-pull-request": true,
+  "prerelease-type": "beta",
+  "prerelease": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable line-length-->
+
+# Changelog


### PR DESCRIPTION
## Purpose

- add a markdownlint ignore entry to the `CHANGELOG.md`
- set `release-please` to use a `pre-release`
- remove the custom `changelog-sections`

## Context

https://github.com/cultureamp/terraform-buildkite-plugin/actions/runs/16014670906/job/45178923596

## Breaking changes

N/A

## Related issues

N/A